### PR TITLE
Replaced "cdn.pika.dev" with "cdn.skypack.dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 Browsers
 </th><td width=100%>
 
-Load `@octokit/plugin-request-log` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.pika.dev](https://cdn.pika.dev)
+Load `@octokit/plugin-request-log` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.skypack.dev](https://cdn.skypack.dev)
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.pika.dev/@octokit/core";
-  import { requestLog } from "https://cdn.pika.dev/@octokit/plugin-request-log";
+  import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
+  import { requestLog } from "https://cdn.skypack.dev/@octokit/plugin-request-log";
 </script>
 ```
 


### PR DESCRIPTION
Replaced "cdn.pika.dev" with "cdn.skypack.dev" in README

fixes #101 