### PR TITLE
feat: add x-github-request-id into logging message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,9 @@ export function requestLog(octokit: Octokit) {
 
     return (request as typeof octokit.request)(options)
       .then((response) => {
+        const requestId = response.headers["x-github-request-id"];
         octokit.log.info(
-          `${requestOptions.method} ${path} - ${response.status} in ${
+          `${requestOptions.method} ${path} - ${response.status} with id ${requestId} in ${
             Date.now() - start
           }ms`,
         );
@@ -24,8 +25,10 @@ export function requestLog(octokit: Octokit) {
       })
 
       .catch((error) => {
-        octokit.log.info(
-          `${requestOptions.method} ${path} - ${error.status} in ${
+        const requestId =
+          error.response.headers["x-github-request-id"] || "UNKNOWN";
+        octokit.log.error(
+          `${requestOptions.method} ${path} - ${error.status} with id ${requestId} in ${
             Date.now() - start
           }ms`,
         );


### PR DESCRIPTION
@gr2m 
@wolfy1339 
@G-Rath 

We had an issue with the github rest api and had a call with @gm3dmo from the github team, where he mentioned, that if we had provided the x-github-request-id, he could have found our api call in splunk faster. 

I thereby propose to log also the requestId, even in the 200 OK cases.