### PR TITLE
fix: dont throw if error does not have response attached

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export function requestLog(octokit: Octokit) {
 
       .catch((error) => {
         const requestId =
-          error.response.headers["x-github-request-id"] || "UNKNOWN";
+          error.response?.headers["x-github-request-id"] || "UNKNOWN";
         octokit.log.error(
           `${requestOptions.method} ${path} - ${error.status} with id ${requestId} in ${
             Date.now() - start


### PR DESCRIPTION
while working on @octokit/rest.js i see a skipped test failing. Seems like a mocked request is resulting in that error. So this PR makes it more resilient.

![image](https://github.com/user-attachments/assets/0b3992c3-9b54-4e12-98ac-5e5a2e4469ce)
